### PR TITLE
fix: make invisible poles immune to electric damage

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -18,6 +18,14 @@ invisible_pole.selection_box = nil
 invisible_pole.collision_box = nil
 invisible_pole.collision_mask = { layers = {} }
 
+invisible_pole.resistances =
+{
+  {
+    type = "electric",
+    percent = 100
+  }
+}
+
 invisible_pole.pictures = {
   layers = {
     {


### PR DESCRIPTION
invisible poles were getting destroyed on fulgora when using rails. this fix did the trick for me